### PR TITLE
Added missing dependencies to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,14 @@ setuptools.setup(
     ],
     package_dir={"": "src"},
     packages=setuptools.find_packages(where="src"),
-    python_requires=">=3.6",
+    install_requires=[
+          'pyyaml',
+          'regex',
+          'matplotlib',
+          'plotly',
+          'scipy',
+          'scikit-learn',
+      ],
+    python_requires=">=3.6, <3.12",
     package_data={'prompt_engine': ['utils/encoder.json', 'utils/vocab.bpe']},
 )


### PR DESCRIPTION
Noticed that the package was missing information about dependencies, so I've added the following;

-    pyyaml
-    regex
-    matplotlib
-    plotly
-    scipy
-    scikit-learn

Also, scipy requires Python < 3.12, so added that too.